### PR TITLE
Refactor a bit how ffmpeg is used to get metadata

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -25,7 +25,7 @@ type nd struct {
 	IndexGroups     string `default:"A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) [Unknown]([)"`
 
 	TranscodingCacheSize string `default:"100MB"` // in MB
-	ProbeCommand         string `default:"ffmpeg -i %s -f ffmetadata"`
+	ProbeCommand         []string `default:"[\"ffmpeg\", \"-\", \"ffmetadata\", \"-i\"]"`
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	DevLogSourceLine           bool   `default:"false"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -25,7 +25,7 @@ type nd struct {
 	IndexGroups     string `default:"A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) [Unknown]([)"`
 
 	TranscodingCacheSize string `default:"100MB"` // in MB
-	ProbeCommand         []string `default:"[\"ffmpeg\", \"-\", \"ffmetadata\", \"-i\"]"`
+	ProbeCommand         string `default:"ffmpeg %s -f ffmetadata"`
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	DevLogSourceLine           bool   `default:"false"`

--- a/scanner/metadata_ffmpeg.go
+++ b/scanner/metadata_ffmpeg.go
@@ -269,23 +269,17 @@ func (m *Metadata) parseDuration(tagName string) float32 {
 }
 
 func createProbeCommand(inputs []string) (string, []string) {
-	cmd := conf.Server.ProbeCommand
-
-	split := strings.Split(cmd, " ")
 	args := make([]string, 0)
-	first := true
-	for _, s := range split {
-		if s == "%s" {
-			for _, inp := range inputs {
-				if !first {
-					args = append(args, "-i")
-				}
-				args = append(args, inp)
-				first = false
-			}
+	args = append(args, conf.Server.ProbeCommand...)
+	args = append(args, "-i")
+	for _, inp := range inputs {
+		// This is the easiest way to avoid flag injections
+		fpath, err := filepath.Abs(inp)
+		if err != nil {
+			log.Warn("Unable to get the path of %s", inp)
 			continue
 		}
-		args = append(args, s)
+		args = append(args, fpath)
 	}
 
 	return args[0], args[1:]

--- a/scanner/metadata_ffmpeg.go
+++ b/scanner/metadata_ffmpeg.go
@@ -269,18 +269,21 @@ func (m *Metadata) parseDuration(tagName string) float32 {
 }
 
 func createProbeCommand(inputs []string) (string, []string) {
+	cmd := conf.Server.ProbeCommand
+	split := strings.Split(cmd, " ")
 	args := make([]string, 0)
-	args = append(args, conf.Server.ProbeCommand...)
-	args = append(args, "-i")
-	for _, inp := range inputs {
-		// This is the easiest way to avoid flag injections
-		fpath, err := filepath.Abs(inp)
-		if err != nil {
-			log.Warn("Unable to get the path of %s", inp)
-			continue
-		}
-		args = append(args, fpath)
-	}
 
+	for _, s := range split {
+		if s == "%s" {
+			for _, inp := range inputs {
+			   // This is the easiest way to avoid flag injections
+			   if fpath, err := filepath.Abs(inp); err != nil{
+				   args = append(args, "-i", fpath)
+			   }
+			}
+		} else {
+			args = append(args, s)
+		}
+	}
 	return args[0], args[1:]
 }


### PR DESCRIPTION
- Streamine some loops
- Use filepath.Abs to prevent files beginning with a dash to
  be interpreted as option flags by ffmpeg