### PR TITLE
Make Login background configurable

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -22,6 +22,8 @@ type nd struct {
 	SessionTimeout string `default:"30m"`
 	BaseURL        string `default:""`
 
+	UILoginBackgroundURL string `default:"https://source.unsplash.com/random/1600x900?music"`
+
 	IgnoredArticles string `default:"The El La Los Las Le Les Os As O A"`
 	IndexGroups     string `default:"A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) [Unknown]([)"`
 

--- a/server/app/serve_index.go
+++ b/server/app/serve_index.go
@@ -30,8 +30,9 @@ func ServeIndex(ds model.DataStore, fs http.FileSystem) http.HandlerFunc {
 		}
 		t, _ = t.Parse(string(indexStr))
 		appConfig := map[string]interface{}{
-			"firstTime": firstTime,
-			"baseURL":   strings.TrimSuffix(conf.Server.BaseURL, "/"),
+			"firstTime":          firstTime,
+			"baseURL":            strings.TrimSuffix(conf.Server.BaseURL, "/"),
+			"loginBackgroundURL": conf.Server.UILoginBackgroundURL,
 		}
 		j, _ := json.Marshal(appConfig)
 		data := map[string]interface{}{

--- a/server/app/serve_index_test.go
+++ b/server/app/serve_index_test.go
@@ -22,6 +22,7 @@ var _ = Describe("ServeIndex", func() {
 
 	BeforeEach(func() {
 		ds = &persistence.MockDataStore{MockedUser: mockUser}
+		conf.Server.UILoginBackgroundURL = ""
 	})
 
 	It("adds app_config to index.html", func() {
@@ -57,7 +58,7 @@ var _ = Describe("ServeIndex", func() {
 		Expect(config).To(HaveKeyWithValue("firstTime", false))
 	})
 
-	It("sets baseURL ", func() {
+	It("sets baseURL", func() {
 		conf.Server.BaseURL = "base_url_test"
 		r := httptest.NewRequest("GET", "/index.html", nil)
 		w := httptest.NewRecorder()
@@ -66,6 +67,17 @@ var _ = Describe("ServeIndex", func() {
 
 		config := extractAppConfig(w.Body.String())
 		Expect(config).To(HaveKeyWithValue("baseURL", "base_url_test"))
+	})
+
+	It("sets the uiLoginBackgroundURL", func() {
+		conf.Server.UILoginBackgroundURL = "my_background_url"
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		ServeIndex(ds, fs)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKeyWithValue("loginBackgroundURL", "my_background_url"))
 	})
 })
 

--- a/ui/src/authProvider.js
+++ b/ui/src/authProvider.js
@@ -1,11 +1,12 @@
 import jwtDecode from 'jwt-decode'
 import md5 from 'md5-hex'
 import baseUrl from './utils/baseUrl'
+import config from './config'
 
 const authProvider = {
   login: ({ username, password }) => {
     let url = baseUrl('/app/login')
-    if (localStorage.getItem('initialAccountCreation')) {
+    if (config.firstTime) {
       url = baseUrl('/app/createAdmin')
     }
     const request = new Request(url, {

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,0 +1,20 @@
+const defaultConfig = {
+  firstTime: false,
+  baseURL: '',
+  loginBackgroundURL: 'https://source.unsplash.com/random/1600x900?music'
+}
+
+let config
+
+try {
+  const appConfig = JSON.parse(window.__APP_CONFIG__)
+
+  config = {
+    ...defaultConfig,
+    ...appConfig
+  }
+} catch (e) {
+  config = defaultConfig
+}
+
+export default config

--- a/ui/src/layout/Login.js
+++ b/ui/src/layout/Login.js
@@ -15,6 +15,7 @@ import LockIcon from '@material-ui/icons/Lock'
 import { Notification, useLogin, useNotify, useTranslate } from 'react-admin'
 
 import LightTheme from '../themes/light'
+import config from '../config'
 
 const useStyles = makeStyles((theme) => ({
   main: {
@@ -23,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '100vh',
     alignItems: 'center',
     justifyContent: 'flex-start',
-    background: 'url(https://source.unsplash.com/random/1600x900?music)',
+    background: `url(${config.loginBackgroundURL})`,
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
     backgroundPosition: 'center'
@@ -253,7 +254,7 @@ const Login = ({ location }) => {
     return errors
   }
 
-  if (localStorage.getItem('initialAccountCreation') === 'true') {
+  if (config.firstTime) {
     return (
       <FormSignUp
         handleSubmit={handleSubmit}

--- a/ui/src/utils/baseUrl.js
+++ b/ui/src/utils/baseUrl.js
@@ -1,5 +1,7 @@
+import config from '../config'
+
 const baseUrl = (path) => {
-  const base = localStorage.getItem('baseURL') || ''
+  const base = config.baseURL || ''
   const parts = [base]
   parts.push(path.replace(/^\//, ''))
   return parts.join('/')


### PR DESCRIPTION
This PR enables configuring the image used in the login background. 

By default, the login shows a random, music related, image from Unsplash.com. With this new configuration, you can set a different image URL to be used as the background. Ex:

```
ND_UILOGINBACKGROUNDURL=https://images.hdqwalls.com/download/5k-colorful-galaxy-ko-1920x1080.jpg
```
You can even set it to a embedded image, with no external lookups. Ex of a black background:
```
ND_UILOGINBACKGROUNDURL=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAAABGdBTUEAALGPC/xhBQAAAiJJREFUeF7t0IEAAAAAw6D5Ux/khVBhwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDBgwIABAwYMGDDwMDDVlwABBWcSrQAAAABJRU5ErkJggg==
```

An invalid URL will cause a blank background (usually white)

This PR should resolve the main issue raised by #102 