### PR TITLE
Simplify a bit ffmpeg's transcoder

### DIFF
--- a/engine/media_streamer.go
+++ b/engine/media_streamer.go
@@ -83,7 +83,7 @@ func (ms *mediaStreamer) NewStream(ctx context.Context, id string, reqFormat str
 			log.Error(ctx, "Error loading transcoding command", "format", format, err)
 			return nil, os.ErrInvalid
 		}
-		out, err := ms.ffm.Start(ctx, t.Command, mf.Path, bitRate, format)
+		out, err := ms.ffm.Start(ctx, t.Command, mf.Path, bitRate)
 		if err != nil {
 			log.Error(ctx, "Error starting transcoder", "id", mf.ID, err)
 			return nil, os.ErrInvalid

--- a/engine/media_streamer_test.go
+++ b/engine/media_streamer_test.go
@@ -182,7 +182,7 @@ type fakeFFmpeg struct {
 	closed bool
 }
 
-func (ff *fakeFFmpeg) Start(ctx context.Context, cmd, path string, maxBitRate int, format string) (f io.ReadCloser, err error) {
+func (ff *fakeFFmpeg) Start(ctx context.Context, cmd, path string, maxBitRate int) (f io.ReadCloser, err error) {
 	ff.r = strings.NewReader(ff.Data)
 	return ff, nil
 }

--- a/engine/transcoder/ffmpeg.go
+++ b/engine/transcoder/ffmpeg.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Transcoder interface {
-	Start(ctx context.Context, command, path string, maxBitRate int, format string) (f io.ReadCloser, err error)
+	Start(ctx context.Context, command, path string, maxBitRate int) (f io.ReadCloser, err error)
 }
 
 func New() Transcoder {
@@ -26,11 +26,11 @@ func New() Transcoder {
 
 type ffmpeg struct{}
 
-func (ff *ffmpeg) Start(ctx context.Context, command, path string, maxBitRate int, format string) (f io.ReadCloser, err error) {
-	arg0, args := createTranscodeCommand(command, path, maxBitRate, format)
+func (ff *ffmpeg) Start(ctx context.Context, command, path string, maxBitRate int) (f io.ReadCloser, err error) {
+	args := createTranscodeCommand(command, path, maxBitRate)
 
-	log.Trace(ctx, "Executing ffmpeg command", "cmd", arg0, "args", args)
-	cmd := exec.Command(arg0, args...)
+	log.Trace(ctx, "Executing ffmpeg command", "cmd", args)
+	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stderr = os.Stderr
 	if f, err = cmd.StdoutPipe(); err != nil {
 		return
@@ -43,7 +43,7 @@ func (ff *ffmpeg) Start(ctx context.Context, command, path string, maxBitRate in
 }
 
 // Path will always be an absolute path
-func createTranscodeCommand(cmd, path string, maxBitRate int, format string) (string, []string) {
+func createTranscodeCommand(cmd, path string, maxBitRate int) []string {
 	split := strings.Split(cmd, " ")
 	for i, s := range split {
 		s = strings.Replace(s, "%s", path, -1)
@@ -51,5 +51,5 @@ func createTranscodeCommand(cmd, path string, maxBitRate int, format string) (st
 		split[i] = s
 	}
 
-	return split[0], split[1:]
+	return split
 }

--- a/engine/transcoder/ffmpeg_test.go
+++ b/engine/transcoder/ffmpeg_test.go
@@ -18,8 +18,7 @@ func TestTranscoder(t *testing.T) {
 
 var _ = Describe("createTranscodeCommand", func() {
 	It("creates a valid command line", func() {
-		cmd, args := createTranscodeCommand("ffmpeg -i %s -b:a %bk mp3 -", "/music library/file.mp3", 123, "")
-		Expect(cmd).To(Equal("ffmpeg"))
-		Expect(args).To(Equal([]string{"-i", "/music library/file.mp3", "-b:a", "123k", "mp3", "-"}))
+		args := createTranscodeCommand("ffmpeg -i %s -b:a %bk mp3 -", "/music library/file.mp3", 123)
+		Expect(args).To(Equal([]string{"ffmpeg", "-i", "/music library/file.mp3", "-b:a", "123k", "mp3", "-"}))
 	})
 })


### PR DESCRIPTION
- Remove the useless "format" parameter
- createTranscodeCommand now returns a list of string, instead of (string, string[])