### PR TITLE
Refactor a bit how ffmpeg is used to get metadata

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -29,7 +29,7 @@ type nd struct {
 
 	TranscodingCacheSize string `default:"100MB"` // in MB
 	ImageCacheSize       string `default:"100MB"` // in MB
-	ProbeCommand         string `default:"ffmpeg -i %s -f ffmetadata"`
+	ProbeCommand         string `default:"ffmpeg %s -f ffmetadata"`
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	DevLogSourceLine           bool   `default:"false"`

--- a/scanner/metadata_ffmpeg.go
+++ b/scanner/metadata_ffmpeg.go
@@ -74,10 +74,10 @@ func LoadAllAudioFiles(dirPath string) (map[string]os.FileInfo, error) {
 }
 
 func ExtractAllMetadata(inputs []string) (map[string]*Metadata, error) {
-	cmdLine, args := createProbeCommand(inputs)
+	args := createProbeCommand(inputs)
 
-	log.Trace("Executing command", "arg0", cmdLine, "args", args)
-	cmd := exec.Command(cmdLine, args...)
+	log.Trace("Executing command", "args", args)
+	cmd := exec.Command(args[0], args[1:]...)
 	output, _ := cmd.CombinedOutput()
 	mds := map[string]*Metadata{}
 	if len(output) == 0 {
@@ -269,25 +269,18 @@ func (m *Metadata) parseDuration(tagName string) float32 {
 }
 
 // Inputs will always be absolute paths
-func createProbeCommand(inputs []string) (string, []string) {
-	cmd := conf.Server.ProbeCommand
-
-	split := strings.Split(cmd, " ")
+func createProbeCommand(inputs []string) []string {
+	split := strings.Split(conf.Server.ProbeCommand, " ")
 	args := make([]string, 0)
-	first := true
+
 	for _, s := range split {
 		if s == "%s" {
 			for _, inp := range inputs {
-				if !first {
-					args = append(args, "-i")
-				}
-				args = append(args, inp)
-				first = false
+				args = append(args, "-i", inp)
 			}
-			continue
+		} else {
+			args = append(args, s)
 		}
-		args = append(args, s)
 	}
-
-	return args[0], args[1:]
+	return args
 }

--- a/scanner/metadata_test.go
+++ b/scanner/metadata_test.go
@@ -228,4 +228,10 @@ Tracklist:
 			Expect(md.Year()).To(Equal(0))
 		})
 	})
+
+	It("creates a valid command line", func() {
+		args := createProbeCommand([]string{"/music library/one.mp3", "/music library/two.mp3"})
+		Expect(args).To(Equal([]string{"ffmpeg", "-i", "/music library/one.mp3", "-i", "/music library/two.mp3", "-f", "ffmetadata" }))
+	})
+
 })


### PR DESCRIPTION
- createProbeCommand returns a []string instead of (string, string[])
- Simplify the loop of createProbeCommand