### PR TITLE
configuration for request throttling

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -26,6 +26,9 @@ const (
 
 	URLPathUI          = "/app"
 	URLPathSubsonicAPI = "/rest"
+
+	RequestThrottleBacklogLimit   = 100
+	RequestThrottleBacklogTimeout = time.Minute
 )
 
 // Cache options


### PR DESCRIPTION
Configuration for ThrottleBacklog middleware. This would reduce server load and memory consumption. Server will process X requests parallel, X is between 2 and max amount of CPUs. 100 Requests will be hold in the queue.

Fixes #184 
