### PR TITLE
Don't run Docker job in contributed PRs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -134,21 +134,27 @@ jobs:
     name: Docker images
     needs: [binaries]
     runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: ${{secrets.DOCKER_IMAGE}}
     steps:
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1
+        if: ${{env.DOCKER_IMAGE}} != ''
         with:
           version: latest
 
       - uses: actions/checkout@v1
+        if: ${{env.DOCKER_IMAGE}} != ''
 
       - uses: actions/download-artifact@v1
+        if: ${{env.DOCKER_IMAGE}} != ''
         with:
           name: binaries
           path: dist
 
       - name: Build the Docker image and push
+        if: ${{env.DOCKER_IMAGE}} != ''
         env:
           DOCKER_IMAGE: ${{secrets.DOCKER_IMAGE}}
           DOCKER_PLATFORM: linux/amd64,linux/arm/v7,linux/arm64


### PR DESCRIPTION
This PR skips the Docker build/push step, as it was always breaking for contributed PRs

Reason is that secrets are not available for PRs coming from a fork: https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow

As there's no way to [check if secrets are available at the job level](https://github.community/t5/GitHub-Actions/How-can-I-test-if-secrets-are-available-in-an-action/td-p/50881), I added the check at each step of the docker job