### PR TITLE
Add `songCount` column to Artist table

### DIFF
--- a/db/migration/20200508093059_add_artist_song_count.go
+++ b/db/migration/20200508093059_add_artist_song_count.go
@@ -1,0 +1,27 @@
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(Up20200508093059, Down20200508093059)
+}
+
+func Up20200508093059(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+alter table artist
+	add song_count integer default 0 not null;
+`)
+	if err != nil {
+		return err
+	}
+	notice(tx, "A full rescan will be performed to calculate artists' song counts")
+	return forceFullRescan(tx)
+}
+
+func Down20200508093059(tx *sql.Tx) error {
+	return nil
+}

--- a/model/artist.go
+++ b/model/artist.go
@@ -5,7 +5,8 @@ import "time"
 type Artist struct {
 	ID              string `json:"id"          orm:"column(id)"`
 	Name            string `json:"name"`
-	AlbumCount      int    `json:"albumCount"  orm:"column(album_count)"`
+	AlbumCount      int    `json:"albumCount"`
+	SongCount       int    `json:"songCount"`
 	FullText        string `json:"fullText"`
 	SortArtistName  string `json:"sortArtistName"`
 	OrderArtistName string `json:"orderArtistName"`

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -114,8 +114,8 @@ func (r *artistRepository) Refresh(ids ...string) error {
 	}
 	var artists []refreshArtist
 	sel := Select("f.album_artist_id as id", "f.album_artist as name", "count(*) as album_count", "a.id as current_id",
-		"f.sort_album_artist_name as sort_artist_name",
-		"f.order_album_artist_name as order_artist_name").
+		"f.sort_album_artist_name as sort_artist_name", "f.order_album_artist_name as order_artist_name",
+		"sum(f.song_count) as song_count").
 		From("album f").
 		LeftJoin("artist a on f.album_artist_id = a.id").
 		Where(Eq{"f.album_artist_id": ids}).

--- a/ui/src/artist/ArtistList.js
+++ b/ui/src/artist/ArtistList.js
@@ -38,6 +38,7 @@ const ArtistList = (props) => (
     <Datagrid rowClick={artistRowClick}>
       <TextField source="name" />
       <NumberField source="albumCount" />
+      <NumberField source="songCount" />
     </Datagrid>
   </List>
 )

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -49,7 +49,8 @@
             "name": "Artist |||| Artists",
             "fields": {
                 "name": "Name",
-                "albumCount": "Album Count"
+                "albumCount": "Album Count",
+                "songCount": "Song Count"
             }
         },
         "user": {


### PR DESCRIPTION
Closes #234 

This change introduces a new term to be translated: `resources.artist.fields.songCount`

<img width="646" alt="Screen Shot 2020-05-08 at 9 55 55 AM" src="https://user-images.githubusercontent.com/331353/81412625-225a3f00-9112-11ea-81d8-158b8c443794.png">
