### PR TITLE
Add [Install] section to systemd unit file.

### DIFF
--- a/contrib/navidrome.service
+++ b/contrib/navidrome.service
@@ -5,6 +5,9 @@ Description=Navidrome Music Server and Streamer compatible with Subsonic/Airsoni
 After=remote-fs.target network.target
 AssertPathExists=/var/lib/navidrome
 
+[Install]
+WantedBy=multi-user.target
+
 [Service]
 User=navidrome
 Group=navidrome


### PR DESCRIPTION
This section apparently is mandatory now.

`multi-user` is a standard target that won't hurt anyone.