### PR TITLE
Correct response body for getSongsByGenre

### DIFF
--- a/server/subsonic/album_lists.go
+++ b/server/subsonic/album_lists.go
@@ -168,7 +168,7 @@ func (c *AlbumListController) GetSongsByGenre(w http.ResponseWriter, r *http.Req
 	}
 
 	response := NewResponse()
-	response.RandomSongs = &responses.Songs{}
-	response.RandomSongs.Songs = ToChildren(r.Context(), songs)
+	response.SongsByGenre = &responses.Songs{}
+	response.SongsByGenre.Songs = ToChildren(r.Context(), songs)
 	return response, nil
 }


### PR DESCRIPTION
`getSongsByGenre` was returning data within the `randomSongs` element. Here's a sample of the XML response from my server:

```
<subsonic-response status="ok" version="1.10.2" type="navidrome" serverVersion="dev">
<randomSongs>
...
</randomSongs>
</subsonic-response>
```
This PR corrects the response so it's properly within a `songsByGenre` element.