### PR TITLE
Remove MUSL build

### DIFF
--- a/.github/workflows/pipeline.dockerfile
+++ b/.github/workflows/pipeline.dockerfile
@@ -6,7 +6,7 @@ ARG TARGETPLATFORM
 RUN echo "Target Platform = ${TARGETPLATFORM}"
 
 COPY dist .
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ];  then cp navidrome_linux_musl_amd64_linux_amd64/navidrome /navidrome; fi
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ];  then cp navidrome_linux_amd64_linux_amd64/navidrome /navidrome; fi
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ];  then cp navidrome_linux_arm64_linux_arm64/navidrome /navidrome; fi
 RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ]; then cp navidrome_linux_arm_linux_arm_6/navidrome /navidrome; fi
 RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then cp navidrome_linux_arm_linux_arm_7/navidrome /navidrome; fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,20 +34,6 @@ builds:
       - "-extldflags '-static'"
       - -X github.com/deluan/navidrome/consts.gitSha={{.ShortCommit}} -X github.com/deluan/navidrome/consts.gitTag={{.Version}}
 
-  - id: navidrome_linux_musl_amd64
-    env:
-      - CGO_ENABLED=1
-      - CC=musl-gcc
-    goos:
-      - linux
-    goarch:
-      - amd64
-    flags:
-      - -tags=embed
-    ldflags:
-      - "-extldflags '-static'"
-      - -X github.com/deluan/navidrome/consts.gitSha={{.ShortCommit}} -X github.com/deluan/navidrome/consts.gitTag={{.Version}}
-
   - id: navidrome_linux_arm
     env:
       - CGO_ENABLED=1
@@ -110,22 +96,7 @@ builds:
       - -X github.com/deluan/navidrome/consts.gitSha={{.ShortCommit}} -X github.com/deluan/navidrome/consts.gitTag={{.Version}}
 
 archives:
-  - id: musl
-    builds:
-      - navidrome_linux_musl_amd64
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_musl_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    replacements:
-      linux: Linux
-      amd64: x86_64
-  - id: default
-    builds:
-      - navidrome_darwin
-      - navidrome_linux_amd64
-      - navidrome_linux_arm
-      - navidrome_linux_arm64
-      - navidrome_windows_i686
-      - navidrome_windows_x64
-    format_overrides:
+  - format_overrides:
       - goos: windows
         format: zip
     replacements:


### PR DESCRIPTION
Latest AMD64 Linux builds are static, so there's no need to generate a binary specifically for MUSL.

Running in the latest Alpine images:
```
# ldd ./navidrome
/lib/ld-musl-x86_64.so.1: ./navidrome: Not a valid dynamic program
#
# ./navidrome help
 _   _             _     _
| \ | |           (_)   | |
|  \| | __ ___   ___  __| |_ __ ___  _ __ ___   ___
| . ` |/ _` \ \ / / |/ _` | '__/ _ \| '_ ` _ \ / _ \
| |\  | (_| |\ V /| | (_| | | | (_) | | | | | |  __/
\_| \_/\__,_| \_/ |_|\__,_|_|  \___/|_| |_| |_|\___|
                 Version: v0.24.0-SNAPSHOT (1bb11bd)

Navidrome is a self-hosted music server and streamer.
Complete documentation is available at https://www.navidrome.org/docs

Usage:
  navidrome [flags]
```

@jvoisin Can you confirm the Linux AMD64 from the [binaries archive](https://github.com/deluan/navidrome/suites/897329280/artifacts/10723260) works for you?

This is related to #142 