### PR TITLE
ByPath queries should not match overlapping paths

### DIFF
--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -137,6 +137,19 @@ var _ = Describe("MediaRepository", func() {
 		Expect(mr.FindAllByPath(P("/Legião Urbana"))).To(HaveLen(0))
 	})
 
+	It("only deletes tracks that match exact path", func() {
+		id1 := "6021"
+		Expect(mr.Put(&model.MediaFile{ID: id1, Path: P("/music/overlap/Ella Fitzgerald/" + id1 + ".mp3")})).To(BeNil())
+		id2 := "6022"
+		Expect(mr.Put(&model.MediaFile{ID: id2, Path: P("/music/overlap/Ella Fitzgerald/" + id2 + ".mp3")})).To(BeNil())
+		id3 := "6023"
+		Expect(mr.Put(&model.MediaFile{ID: id3, Path: P("/music/overlap/Ella Fitzgerald & Louis Armstrong - They Can't Take That Away From Me.mp3")})).To(BeNil())
+
+		Expect(mr.FindAllByPath(P("/music/overlap/Ella Fitzgerald"))).To(HaveLen(2))
+		Expect(mr.DeleteByPath(P("/music/overlap/Ella Fitzgerald"))).To(Equal(int64(2)))
+		Expect(mr.FindAllByPath(P("/music/overlap"))).To(HaveLen(1))
+	})
+
 	Context("Annotations", func() {
 		It("increments play count when the tracks does not have annotations", func() {
 			id := "incplay.firsttime"


### PR DESCRIPTION
This fix an issue where the scanner would end up with empty albums if any filepath starts with the album's path. Ex:

Contents of Music Folder:
```
/music/Ella Fitzgerald/1.mp3
/music/Ella Fitzgerald/2.mp3
/music/Ella Fitzgerald & Louis Armstrong - 3.mp3
/music/Ella Fitzgerald & Louis Armstrong - 4.mp3
```
This would cause the album composed by files 3 and 4 to be empty. The songs would be deleted from the DB because of the overlapping path.