### PR TITLE
Fixed playlist duration formatter to properly count lengths longer than 24 hours

### DIFF
--- a/ui/src/common/DurationField.js
+++ b/ui/src/common/DurationField.js
@@ -11,10 +11,13 @@ const DurationField = ({ record = {}, source }) => {
 }
 
 const format = (d) => {
-  const date = new Date(null)
-  date.setSeconds(d)
-  const fmt = date.toISOString().substr(11, 8)
-  return fmt.replace(/^00:/, '')
+  const hours   = Math.floor(d / 3600)
+  const minutes = Math.floor(d / 60) % 60
+  const seconds = d % 60
+  return [hours,minutes,seconds]
+     .map(v => v < 10 ? "0" + v : v)
+     .filter((v,i) => v !== "00" || i > 0)
+     .join(":")
 }
 
 DurationField.propTypes = {

--- a/ui/src/common/DurationField.js
+++ b/ui/src/common/DurationField.js
@@ -11,13 +11,13 @@ const DurationField = ({ record = {}, source }) => {
 }
 
 const format = (d) => {
-  const hours   = Math.floor(d / 3600)
+  const hours = Math.floor(d / 3600)
   const minutes = Math.floor(d / 60) % 60
   const seconds = d % 60
-  return [hours,minutes,seconds]
-     .map(v => v < 10 ? "0" + v : v)
-     .filter((v,i) => v !== "00" || i > 0)
-     .join(":")
+  return [hours, minutes, seconds]
+    .map((v) => (v < 10 ? '0' + v : v))
+    .filter((v, i) => v !== '00' || i > 0)
+    .join(':')
 }
 
 DurationField.propTypes = {


### PR DESCRIPTION
This is a small fix to properly display a playlists length when it would go above 24 hours in length.
Previously, the length of the playlist shown would be the modulo over 24 hours, so a playlist of 26 hours would display as 02:00:00. With this fix it will display as 26:00:00.