### PR TITLE
Fix default getPerPage for 'md' widths

### DIFF
--- a/ui/src/common/useAlbumsPerPage.js
+++ b/ui/src/common/useAlbumsPerPage.js
@@ -4,7 +4,7 @@ import get from 'lodash.get'
 const getPerPage = (width) => {
   if (width === 'xs') return 12
   if (width === 'sm') return 12
-  if (width === 'md') return 15
+  if (width === 'md') return 12
   if (width === 'lg') return 18
   return 36
 }


### PR DESCRIPTION
Currently, `getPerPage()` for a width of 'md' will return `15` as the default `perPage` value, but offer the choices of 12, 24, 48 for "Items per page." This resolves that issue.