### PR TITLE
Fix aspect ratio for non-square album art.

### DIFF
--- a/core/artwork.go
+++ b/core/artwork.go
@@ -171,7 +171,16 @@ func resizeImage(reader io.Reader, size int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	m := imaging.Resize(img, size, size, imaging.Lanczos)
+
+	// Preserve the aspect ratio of the image.
+	var m *image.NRGBA
+	bounds := img.Bounds()
+	if bounds.Max.X > bounds.Max.Y {
+		m = imaging.Resize(img, size, 0, imaging.Lanczos)
+	} else {
+		m = imaging.Resize(img, 0, size, imaging.Lanczos)
+	}
+
 	buf := new(bytes.Buffer)
 	err = jpeg.Encode(buf, m, &jpeg.Options{Quality: conf.Server.CoverJpegQuality})
 	return buf.Bytes(), err

--- a/ui/src/album/AlbumDetails.js
+++ b/ui/src/album/AlbumDetails.js
@@ -63,10 +63,11 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   cover: {
+    objectFit: 'contain',
     cursor: 'pointer',
     display: 'block',
     width: '100%',
-    height: 'auto',
+    height: '100%',
   },
   starButton: {
     top: theme.spacing(-0.2),

--- a/ui/src/album/AlbumGridView.js
+++ b/ui/src/album/AlbumGridView.js
@@ -77,6 +77,7 @@ const useCoverStyles = makeStyles({
   cover: {
     display: 'inline-block',
     width: '100%',
+    'object-fit': 'contain',
     height: (props) => props.height,
   },
 })

--- a/ui/src/album/AlbumGridView.js
+++ b/ui/src/album/AlbumGridView.js
@@ -77,7 +77,7 @@ const useCoverStyles = makeStyles({
   cover: {
     display: 'inline-block',
     width: '100%',
-    'object-fit': 'contain',
+    objectFit: 'contain',
     height: (props) => props.height,
   },
 })


### PR DESCRIPTION
If you have non-square album art for an album (maybe you ripped music from a DVD and have a DVD-sized cover, or maybe you just [enjoy the Cat Face theme song](https://www.youtube.com/watch?v=WlDiUQy-C64) more than you should and you grabbed a YouTube thumbnail for the cover art), then Navidrome messes up the aspect ratio.  This PR changes the album grid from this:

![Screen Shot 2020-11-22 at 11 10 15 AM](https://user-images.githubusercontent.com/1771003/99909038-1734be00-2cb4-11eb-874a-aace73fb2e8e.png)

To this:

![Screen Shot 2020-11-22 at 11 09 37 AM](https://user-images.githubusercontent.com/1771003/99909042-1bf97200-2cb4-11eb-8a95-ebbedf9520c6.png)

(Also, this is my very first commit to a golang project, and I don't actually know any golang, so apologies if there was a much easier way to do this.  :)
