### PR TITLE
Adjust AudioTitle in Player

### DIFF
--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -41,10 +41,6 @@ const useStyle = makeStyles((theme) => ({
 
 let audioInstance = null
 
-const audioTitle = (audioInfo) => {
-  return audioInfo.name ? `${audioInfo.name} - ${audioInfo.singer}` : ''
-}
-
 const AudioTitle = ({ audioInfo, className }) => {
   if (!audioInfo.name) {
     return ''
@@ -167,7 +163,6 @@ const Player = () => {
       destroyText: translate('player.destroyText'),
       downloadText: translate('player.downloadText'),
       removeAudioListsText: translate('player.removeAudioListsText'),
-      audioTitle: audioTitle,
       clickToDeleteText: (name) =>
         translate('player.clickToDeleteText', { name }),
       emptyLyricText: translate('player.emptyLyricText'),

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -24,6 +24,15 @@ const useStyle = makeStyles((theme) => ({
   audioTitle: {
     textDecoration: 'none',
     color: theme.palette.primary.light,
+    '&.songTitle': {
+      fontWeight: 'bold',
+    },
+    '&.songInfo': {
+      // 768 is where the player swaps views
+      [theme.breakpoints.down(769)]: {
+        display: 'none',
+      },
+    },
   },
   player: {
     display: (props) => (props.visible ? 'block' : 'none'),
@@ -37,10 +46,17 @@ const audioTitle = (audioInfo) => {
 }
 
 const AudioTitle = ({ audioInfo, className }) => {
-  const title = audioTitle(audioInfo)
+  if (!audioInfo.name) {
+    return ''
+  }
+
   return (
     <Link to={`/album/${audioInfo.albumId}/show`} className={className}>
-      {title}
+      <span className={`${className} songTitle`}>{audioInfo.name}</span>
+      <br />
+      <span className={`${className} songInfo`}>
+        {`${audioInfo.singer} - ${audioInfo.album}`}
+      </span>
     </Link>
   )
 }


### PR DESCRIPTION
This adjusts the AudioTitle component in the Player to:
- Show info on 2 lines, bolding the song title
- Show album

The second line is hidden on small screens when the player swaps to its mobile view.