### PR TITLE
Fall back to artist and title after track id when sorting in albums

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -77,7 +77,7 @@ func (r mediaFileRepository) GetAll(options ...model.QueryOptions) (model.MediaF
 }
 
 func (r mediaFileRepository) FindByAlbum(albumId string) (model.MediaFiles, error) {
-	sel := r.selectMediaFile().Where(Eq{"album_id": albumId}).OrderBy("disc_number", "track_number", "artist", "title")
+	sel := r.selectMediaFile(model.QueryOptions{Sort: "album"}).Where(Eq{"album_id": albumId})
 	res := model.MediaFiles{}
 	err := r.queryAll(sel, &res)
 	return res, err

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -27,7 +27,7 @@ func NewMediaFileRepository(ctx context.Context, o orm.Ormer) *mediaFileReposito
 	r.tableName = "media_file"
 	r.sortMappings = map[string]string{
 		"artist": "order_artist_name asc, album asc, disc_number asc, track_number asc",
-		"album":  "order_album_name asc, disc_number asc, track_number asc",
+		"album":  "order_album_name asc, disc_number asc, track_number asc, artist asc, title asc",
 		"random": "RANDOM()",
 	}
 	r.filterMappings = map[string]filterFunc{
@@ -77,7 +77,7 @@ func (r mediaFileRepository) GetAll(options ...model.QueryOptions) (model.MediaF
 }
 
 func (r mediaFileRepository) FindByAlbum(albumId string) (model.MediaFiles, error) {
-	sel := r.selectMediaFile().Where(Eq{"album_id": albumId}).OrderBy("disc_number", "track_number")
+	sel := r.selectMediaFile().Where(Eq{"album_id": albumId}).OrderBy("disc_number", "track_number", "artist", "title")
 	res := model.MediaFiles{}
 	err := r.queryAll(sel, &res)
 	return res, err

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -26,8 +26,8 @@ func NewMediaFileRepository(ctx context.Context, o orm.Ormer) *mediaFileReposito
 	r.ormer = o
 	r.tableName = "media_file"
 	r.sortMappings = map[string]string{
-		"artist": "order_artist_name asc, album asc, disc_number asc, track_number asc",
-		"album":  "order_album_name asc, disc_number asc, track_number asc, artist asc, title asc",
+		"artist": "order_artist_name asc, order_album_name asc, disc_number asc, track_number asc",
+		"album":  "order_album_name asc, disc_number asc, track_number asc, order_artist_name asc, title asc",
 		"random": "RANDOM()",
 	}
 	r.filterMappings = map[string]filterFunc{

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -42,8 +42,8 @@ var _ = Describe("MediaRepository", func() {
 
 	It("find mediafiles by album", func() {
 		Expect(mr.FindByAlbum("103")).To(Equal(model.MediaFiles{
-			songRadioactivity,
 			songAntenna,
+			songRadioactivity,
 		}))
 	})
 

--- a/ui/src/album/AlbumShow.js
+++ b/ui/src/album/AlbumShow.js
@@ -22,7 +22,7 @@ const AlbumShowLayout = (props) => {
           addLabel={false}
           reference="albumSong"
           target="album_id"
-          sort={{ field: 'discNumber asc, trackNumber asc', order: 'ASC' }}
+          sort={{ field: 'album', order: 'ASC' }}
           perPage={0}
           pagination={null}
         >


### PR DESCRIPTION
If files cannot be sorted according to the query, fall back to ascending/descending file names.

One use case is a loose compilation of files with same album, album artist, and no track numbers. File order was then undetermined, in practice depended on insertion order in the database.