### PR TITLE
Check for window.isSecureContext when determining Notification support

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -265,7 +265,7 @@
         "delete_user_title": "Delete user '%{name}'",
         "delete_user_content": "Are you sure you want to delete this user and all their data (including playlists and preferences)?",
         "notifications_blocked": "You have blocked Notifications for this site in your browser's settings",
-        "notifications_not_available": "This browser does not support desktop notifications"
+        "notifications_not_available": "This browser does not support desktop notifications or you are not accessing Navidrome over https"
     },
     "menu": {
         "library": "Library",

--- a/ui/src/personal/Personal.js
+++ b/ui/src/personal/Personal.js
@@ -131,7 +131,7 @@ const NotificationsToggle = () => {
   const dispatch = useDispatch()
   const notify = useNotify()
   const currentSetting = useSelector((state) => state.settings.notifications)
-  const notAvailable = !('Notification' in window)
+  const notAvailable = !('Notification' in window) || !window.isSecureContext
 
   if (
     (currentSetting && Notification.permission !== 'granted') ||


### PR DESCRIPTION
This fixes the Notification preference switch being enabled but nonfunctional when the UI was not accessed in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). It will now be disabled and show the proper message.